### PR TITLE
feat: add ujust-picker and modernize user-space management

### DIFF
--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -1,0 +1,370 @@
+# Hublue Command Cheatsheet
+
+## 🎯 Quick Start
+
+```bash
+# After first boot - run this once
+ujust setup-user
+```
+
+## 🔍 Command Discovery
+
+```bash
+# Interactive TUI picker (easiest way!)
+ujust-picker
+# or
+ujust picker
+
+# List all available commands
+ujust --list
+
+# Interactive selection
+ujust --choose
+```
+
+## 📦 User Setup
+
+```bash
+# Complete setup (all-in-one)
+ujust setup-user
+
+# Individual steps
+ujust install-brew          # Install Homebrew
+ujust install-omz           # Install oh-my-zsh
+ujust install-brew-packages # Install CLI tools from Brewfile
+ujust configure-shell       # Configure bash/zsh
+ujust install-kubecolor     # Install kubecolor
+ujust set-zsh-default       # Set zsh as default shell
+
+# Update user packages
+ujust update-user
+```
+
+## 🐳 Development Environments
+
+```bash
+# Create Go development toolbox
+ujust create-go-toolbox
+distrobox enter go-dev
+
+# Create general development toolbox
+ujust create-dev-toolbox myproject
+distrobox enter myproject
+
+# List all toolboxes
+distrobox list
+
+# Remove a toolbox
+distrobox rm go-dev
+```
+
+## 📦 Package Management
+
+```bash
+# System packages (requires reboot)
+rpm-ostree install package-name
+systemctl reboot
+
+# User packages (Homebrew)
+brew install package-name
+brew upgrade
+brew search package-name
+
+# In toolbox (any package)
+distrobox enter go-dev
+sudo dnf install whatever-you-want
+```
+
+## 🔄 System Updates
+
+```bash
+# Update system image
+ujust update
+# or
+rpm-ostree update
+systemctl reboot
+
+# Update Homebrew packages
+ujust update-user
+# or
+brew update && brew upgrade
+
+# Update toolboxes
+distrobox upgrade --all
+```
+
+## 🛠️ Common Aliases
+
+Already configured in your shell:
+
+```bash
+# Modern CLI replacements (via ublue-bling)
+ls      # -> eza (modern ls)
+ll      # -> eza -l --icons=auto --group-directories-first
+cat     # -> bat (syntax highlighting)
+grep    # -> ugrep (faster grep)
+
+# Custom aliases (in ~/.zshrc)
+k       # -> kubecolor (kubectl with colors)
+tx      # -> toolbox (shortcut)
+
+# Homebrew tools
+z       # -> zoxide (smart cd)
+```
+
+## 🐹 Go Development
+
+```bash
+# Create Go environment
+ujust create-go-toolbox
+
+# Enter and develop
+distrobox enter go-dev
+cd ~/Projects/myproject
+go build
+go test
+go run main.go
+
+# Exit
+exit
+```
+
+## ☸️ Kubernetes
+
+```bash
+# kubectl with colors (alias: k)
+k get pods
+k describe pod mypod
+k logs -f mypod
+
+# Switch contexts
+k config use-context my-context
+
+# View all contexts
+k config get-contexts
+```
+
+## 🔐 Container Management
+
+```bash
+# Podman (Docker-compatible)
+podman ps
+podman images
+podman build -t myimage .
+podman run -it myimage
+
+# Buildah (advanced builds)
+buildah bud -t myimage .
+buildah from fedora:42
+
+# Compose
+podman-compose up -d
+podman-compose down
+```
+
+## 📁 File Navigation
+
+```bash
+# zoxide (smart cd)
+z myproject    # Jump to frequently used directory
+zi             # Interactive directory picker
+
+# eza (modern ls)
+eza            # Basic list
+ll             # Long format with icons
+l1             # One file per line
+l.             # List hidden files
+
+# fd (modern find)
+fd pattern
+fd -e go       # Find all .go files
+```
+
+## 🔍 Search
+
+```bash
+# ugrep (fast grep)
+ug pattern
+ug -r pattern  # Recursive
+ug -i pattern  # Case insensitive
+
+# ripgrep (also available)
+rg pattern
+```
+
+## 🎨 Shell Enhancements
+
+```bash
+# starship (already active)
+# Shows git status, directory, etc.
+
+# atuin (shell history)
+Ctrl+R         # Search history (better than default)
+atuin search query
+atuin stats
+
+# direnv (auto-load .envrc)
+cd myproject   # Automatically loads .envrc if present
+```
+
+## 🧰 Development Tools
+
+```bash
+# Neovim
+nvim file.go
+
+# Git
+git status
+git commit -m "message"
+git push
+
+# GitHub CLI
+gh repo view
+gh pr create
+gh issue list
+
+# jq (JSON processor)
+curl api.com/data | jq '.items[]'
+
+# yq (YAML processor)
+yq '.spec.replicas' deployment.yaml
+```
+
+## 🖥️ Terminal
+
+```bash
+# Zellij (terminal multiplexer)
+zellij         # Start session
+Ctrl+T         # New tab
+Ctrl+P         # New pane
+Ctrl+Q         # Quit
+
+# Ghostty (terminal emulator)
+# Already your default terminal!
+```
+
+## 🆘 Help & Info
+
+```bash
+# Get help on any ujust command
+ujust --help
+
+# List all commands with groups
+ujust --list
+
+# Interactive command browser
+ujust-picker
+
+# Check system status
+rpm-ostree status
+
+# View logs
+journalctl -xe
+```
+
+## 🔧 Customization
+
+```bash
+# Edit shell config
+nvim ~/.zshrc     # or ~/.bashrc
+
+# Edit Brewfile (add packages)
+cp /usr/share/hublue/Brewfile ~/Brewfile
+nvim ~/Brewfile
+brew bundle --file=~/Brewfile
+
+# Edit ujust commands
+sudo nvim /usr/share/ublue-os/just/60-hublue.just
+
+# Add custom dotfiles
+chezmoi init
+chezmoi add ~/.zshrc
+```
+
+## 🐛 Troubleshooting
+
+```bash
+# Tools not in PATH
+source ~/.bashrc  # or ~/.zshrc
+
+# Homebrew issues
+brew doctor
+
+# Toolbox issues
+distrobox list
+distrobox logs go-dev
+
+# System issues
+journalctl -b     # Current boot logs
+systemctl status  # System status
+```
+
+## 📚 Documentation
+
+- **USER-SETUP.md** - Complete setup guide
+- **GO-DEVELOPMENT.md** - Go workflow
+- **COMPARISON.md** - Approach comparison
+- **SECURE-BOOT.md** - Security guide
+- **build_files/README.md** - Technical docs
+
+## 💡 Pro Tips
+
+1. **Use `ujust-picker`** for command discovery
+2. **Use distrobox** for all development work
+3. **Keep the host system minimal** - install in toolboxes
+4. **Use `z`** instead of `cd` for navigation
+5. **Use `ll`** instead of `ls -la`
+6. **Use `k`** instead of `kubectl`
+7. **Press Ctrl+R** for atuin history search
+8. **Use `bat`** instead of `cat` for syntax highlighting
+9. **Create project-specific toolboxes** for isolation
+10. **Export commands from toolbox** with `distrobox-export`
+
+## 🎓 Learning Resources
+
+```bash
+# Learn ujust commands interactively
+ujust-picker
+
+# Learn distrobox
+distrobox --help
+
+# Learn Homebrew
+brew help
+
+# Learn each tool
+tool-name --help
+man tool-name
+```
+
+## ⚡ One-Liners
+
+```bash
+# Update everything
+ujust update && ujust update-user && distrobox upgrade --all
+
+# Create and enter toolbox
+ujust create-go-toolbox && distrobox enter go-dev
+
+# Search command history
+Ctrl+R
+
+# Quick file search
+fd filename
+
+# Quick content search
+ug "search term"
+
+# Jump to project
+z myproject
+
+# View pretty JSON
+cat file.json | jq .
+
+# Check system image info
+rpm-ostree status
+```
+
+---
+
+**Remember:** Run `ujust-picker` anytime you forget a command! 🎯

--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -1,0 +1,253 @@
+# User-Space Management Comparison
+
+## Overview
+
+Here's a comparison of different approaches to manage user-space tools on Hublue (an immutable/atomic OS).
+
+## Approaches
+
+### 1. ✅ ujust Commands (Recommended)
+
+**How it works:**
+```bash
+ujust setup-user
+```
+
+**Pros:**
+- ✅ Built into the system image
+- ✅ Idempotent (safe to run multiple times)
+- ✅ Self-documenting (`ujust --list`)
+- ✅ Universal Blue standard
+- ✅ Survives system updates
+- ✅ Can be automated or manual
+- ✅ Easy to customize
+
+**Cons:**
+- ⚠️ Requires understanding of `just` syntax for customization
+
+**When to use:** Default choice for all users
+
+**Files:**
+- `/usr/share/ublue-os/just/60-hublue.just`
+- `/usr/share/hublue/Brewfile`
+
+---
+
+### 2. ✅ Brewfile (Declarative Packages)
+
+**How it works:**
+```bash
+brew bundle --file=/usr/share/hublue/Brewfile
+```
+
+**Pros:**
+- ✅ Declarative (version-controlled)
+- ✅ Reproducible across machines
+- ✅ Standard Homebrew pattern
+- ✅ Easy to understand
+- ✅ Can check into git
+
+**Cons:**
+- ⚠️ Requires Homebrew installed first
+- ⚠️ Only manages Homebrew packages
+
+**When to use:** Combined with ujust, or for teams sharing package lists
+
+**Files:**
+- `/usr/share/hublue/Brewfile`
+- Custom: `~/Brewfile`
+
+---
+
+### 3. ✅ Distrobox/Toolbox (For Development)
+
+**How it works:**
+```bash
+ujust create-dev-toolbox myproject
+distrobox enter myproject
+sudo dnf install whatever-you-need
+```
+
+**Pros:**
+- ✅ Complete isolation from host
+- ✅ Can use different distros (Fedora, Ubuntu, Arch, etc.)
+- ✅ Multiple environments
+- ✅ Easy to delete and recreate
+- ✅ Doesn't pollute host system
+- ✅ Can install anything (even conflicting versions)
+
+**Cons:**
+- ⚠️ Slight overhead (minimal)
+- ⚠️ Need to enter the container
+
+**When to use:**
+- Project-specific dependencies
+- Different language versions (Python 3.9 vs 3.12)
+- Experimental tools
+- Database servers, dev services
+
+**Files:**
+- `~/.local/share/containers/storage/`
+
+---
+
+### 4. ⚡ Fleek (Nix-based)
+
+**How it works:**
+```bash
+fleek init
+fleek add eza starship atuin
+```
+
+**Pros:**
+- ✅ Most reproducible (Nix)
+- ✅ Declarative YAML config
+- ✅ Huge package selection
+- ✅ Per-user, no root needed
+- ✅ Works on any Linux distro
+- ✅ Can pin exact versions
+- ✅ Includes dotfile management
+
+**Cons:**
+- ⚠️ Learning curve (Nix concepts)
+- ⚠️ Larger disk usage
+- ⚠️ Not a Universal Blue standard
+
+**When to use:**
+- Maximum reproducibility needed
+- Managing multiple machines
+- Want Nix package ecosystem
+- Power users
+
+**Files:**
+- `~/.local/share/fleek/`
+- `~/.fleek.yml`
+
+---
+
+### 5. ⚙️ Chezmoi (Dotfile Manager)
+
+**How it works:**
+```bash
+chezmoi init
+chezmoi add ~/.zshrc ~/.bashrc
+chezmoi apply
+```
+
+**Pros:**
+- ✅ Excellent dotfile management
+- ✅ Templates (different configs per machine)
+- ✅ Encryption support
+- ✅ Git-based
+- ✅ Works anywhere
+
+**Cons:**
+- ⚠️ Only manages dotfiles, not packages
+- ⚠️ Need to learn templating syntax
+
+**When to use:**
+- Syncing dotfiles across machines
+- Team sharing configurations
+- Complex per-machine setups
+
+**Files:**
+- `~/.local/share/chezmoi/`
+- Git repo with your dotfiles
+
+---
+
+### 6. ⚠️ Systemd User Unit (Auto-run)
+
+**How it works:**
+Automatically runs `ujust setup-user` on first login
+
+**Pros:**
+- ✅ Fully automatic
+- ✅ User doesn't need to remember
+- ✅ Only runs once
+
+**Cons:**
+- ⚠️ Less control
+- ⚠️ Harder to debug if it fails
+- ⚠️ User doesn't learn the commands
+
+**When to use:**
+- Deploying to non-technical users
+- Kiosks or managed systems
+- Want zero user intervention
+
+**Files:**
+- `/etc/skel/.config/systemd/user/hublue-setup.service`
+
+---
+
+## Recommended Combinations
+
+### For Individual Users (Simple)
+```bash
+# One-time setup
+ujust setup-user
+
+# Update packages
+ujust update-user
+
+# Development work
+ujust create-dev-toolbox myproject
+distrobox enter myproject
+```
+
+### For Individual Users (Advanced)
+```bash
+# Setup with Fleek for max reproducibility
+fleek init
+fleek add eza starship atuin bat fd
+
+# Dotfiles with chezmoi
+chezmoi init --apply git@github.com:me/dotfiles.git
+
+# Dev environments with distrobox
+distrobox create -n python-dev -i python:3.12
+distrobox create -n node-dev -i node:20
+```
+
+### For Teams
+1. **Fork Hublue repo**
+2. **Customize Brewfile** with team tools
+3. **Add team-specific ujust commands**
+4. **Document in README**
+5. **Team members run:**
+   ```bash
+   ujust setup-user
+   ```
+
+### For Managed Deployments
+1. **Enable systemd auto-setup** in build.sh
+2. **Customize Brewfile** for org needs
+3. **Image deploys and auto-configures**
+4. **Users just login and work**
+
+## Summary
+
+| Approach | Complexity | Resilience | Reproducibility | Use Case |
+|----------|-----------|-----------|-----------------|----------|
+| **ujust** | Low | High | High | Default choice |
+| **Brewfile** | Low | High | High | Package management |
+| **Distrobox** | Medium | High | High | Development |
+| **Fleek** | High | Very High | Very High | Power users |
+| **Chezmoi** | Medium | High | High | Dotfile sync |
+| **Systemd Unit** | Medium | High | High | Managed systems |
+
+## Best Practice
+
+**Use a layered approach:**
+
+1. **System level** (build.sh): DNF packages, system config
+2. **User level** (ujust): Homebrew, shell setup, common tools
+3. **Project level** (distrobox): Project-specific dependencies
+4. **Dotfiles** (chezmoi): Personal configurations
+
+This gives you:
+- ✅ Reproducible base system
+- ✅ Flexible user environment  
+- ✅ Isolated project environments
+- ✅ Portable configurations

--- a/GO-DEVELOPMENT.md
+++ b/GO-DEVELOPMENT.md
@@ -1,0 +1,364 @@
+# Go Development on Hublue
+
+## TL;DR: Use Distrobox for Go Development
+
+On immutable operating systems like Bluefin, **development languages should live in toolboxes**, not the base system.
+
+## Quick Start
+
+```bash
+# Create a Go development environment
+ujust create-go-toolbox
+
+# Enter it
+distrobox enter go-dev
+
+# Your projects are already there!
+cd ~/Projects/github.com/yourproject
+
+# Develop normally
+go build
+go test
+go run main.go
+```
+
+That's it! Your `~/Projects` directory is automatically mounted.
+
+## Why Not System-Level Go?
+
+### ❌ System-Level Installation
+```bash
+# Go installed in /usr/local/bin/go (280MB in base image)
+```
+
+**Problems:**
+- **280MB in every image layer** - bloats your base image
+- **One version only** - Can't have Go 1.21 for one project and 1.24 for another
+- **Immutable** - Requires image rebuild to update Go
+- **Not the pattern** - Universal Blue recommends toolboxes for dev tools
+- **Wastes space** - If you're not developing right now, Go sits there unused
+
+### ✅ Distrobox/Toolbox Installation
+```bash
+# Go installed per-toolbox
+ujust create-go-toolbox
+distrobox enter go-dev
+```
+
+**Benefits:**
+- **0MB in base image** - Keep the host system lean
+- **Multiple versions** - Different toolbox per Go version
+- **Easy to update** - `sudo dnf upgrade golang` inside the toolbox
+- **Isolated** - Project dependencies don't pollute the host
+- **Best practice** - The Universal Blue way
+- **Disposable** - Delete and recreate toolboxes anytime
+
+## Comparison
+
+| Aspect | System-Level | Distrobox |
+|--------|-------------|-----------|
+| Base image size | +280MB | +0MB |
+| Update Go | Rebuild image | `sudo dnf upgrade` |
+| Multiple versions | ❌ No | ✅ Yes |
+| Per-project isolation | ❌ No | ✅ Yes |
+| Host system impact | High | None |
+| Universal Blue pattern | ❌ No | ✅ Yes |
+| Setup time | Slow (image build) | Fast (~30 sec) |
+| Flexibility | Low | High |
+
+## Development Workflow
+
+### Old Way (System-Level)
+```bash
+# On the host
+cd ~/Projects/myproject
+go build  # Uses system Go
+```
+
+**Issues:**
+- All projects share the same Go version
+- Can't experiment with newer Go versions
+- `go.mod` might require different Go version
+- System updates might break builds
+
+### New Way (Distrobox)
+```bash
+# Create project-specific toolbox
+distrobox create -n myproject-go \
+    -i registry.fedoraproject.org/fedora-toolbox:42 \
+    --additional-packages "golang git make gcc"
+
+# Enter toolbox
+distrobox enter myproject-go
+
+# Your project is already there!
+cd ~/Projects/myproject
+go build  # Uses toolbox Go
+```
+
+**Benefits:**
+- Project isolation
+- Easy to pin Go versions
+- Can install project-specific tools
+- Delete toolbox when project is done
+
+## Common Scenarios
+
+### Scenario 1: Different Go Versions
+
+```bash
+# Project A needs Go 1.21
+distrobox create -n project-a \
+    -i registry.fedoraproject.org/fedora-toolbox:39 \
+    --additional-packages "golang"
+
+# Project B needs Go 1.24
+distrobox create -n project-b \
+    -i registry.fedoraproject.org/fedora-toolbox:42 \
+    --additional-packages "golang"
+
+# Use each independently
+distrobox enter project-a  # Go 1.21
+distrobox enter project-b  # Go 1.24
+```
+
+### Scenario 2: General Go Development
+
+```bash
+# One general-purpose Go toolbox
+ujust create-go-toolbox
+
+# Enter it whenever you need Go
+distrobox enter go-dev
+
+# Optional: Create an alias
+echo 'alias go-dev="distrobox enter go-dev"' >> ~/.zshrc
+
+# Now just: go-dev
+```
+
+### Scenario 3: Go with Additional Tools
+
+```bash
+# Create toolbox with Go + tools
+distrobox create -n go-full \
+    -i registry.fedoraproject.org/fedora-toolbox:42 \
+    --additional-packages "golang git make gcc gopls delve staticcheck golangci-lint"
+
+distrobox enter go-full
+
+# Full Go development environment!
+gopls -v          # Language server
+dlv debug         # Debugger  
+staticcheck ./... # Linter
+```
+
+## IDE Integration
+
+### VS Code
+
+Your IDE works seamlessly with distrobox!
+
+```bash
+# Enter the toolbox
+distrobox enter go-dev
+
+# Start VS Code from inside
+code ~/Projects/myproject
+```
+
+Or use the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers).
+
+### GoLand / IntelliJ
+
+Set the Go SDK path to point to the toolbox:
+
+```
+~/.local/share/containers/storage/volumes/go-dev/_data/usr/bin/go
+```
+
+Or run GoLand from inside the toolbox.
+
+### Neovim / vim-go
+
+Inside the toolbox, everything works normally:
+
+```bash
+distrobox enter go-dev
+nvim main.go  # gopls, delve, etc. all work
+```
+
+## Advanced: Pre-configured Toolboxes
+
+### Using distrobox-assemble
+
+Create `/usr/share/hublue/distrobox-configs/go-dev.ini`:
+
+```ini
+[go-dev]
+image=registry.fedoraproject.org/fedora-toolbox:42
+additional_packages="golang git make gcc gopls delve staticcheck"
+init=false
+nvidia=false
+pull=true
+```
+
+Then:
+```bash
+distrobox assemble create --file /usr/share/hublue/distrobox-configs/go-dev.ini
+```
+
+Or just:
+```bash
+ujust create-go-toolbox
+```
+
+## Migrating from System Go
+
+If you previously installed Go system-level:
+
+### 1. Remove from build.sh
+
+Already done! Go installation removed from `/var/home/hubeadmin/Projects/github.com/hubeadmin/hublue/build_files/build.sh`
+
+### 2. Create Go toolbox
+
+```bash
+# After deploying the new image
+ujust create-go-toolbox
+```
+
+### 3. Update your workflow
+
+```bash
+# Old: on host
+cd ~/Projects/myproject
+go build
+
+# New: in toolbox
+distrobox enter go-dev
+cd ~/Projects/myproject
+go build
+```
+
+### 4. Optional: Shell alias
+
+Make it seamless:
+
+```bash
+# Add to ~/.zshrc
+alias go-dev="distrobox enter go-dev"
+
+# Now you can:
+go-dev
+cd ~/Projects/myproject
+go build
+```
+
+Or even better - export Go commands:
+
+```bash
+# Inside the toolbox
+distrobox-export --bin /usr/bin/go --export-path ~/.local/bin
+
+# Now `go` command works on the host, but uses the toolbox!
+go version  # Works from host, runs in toolbox
+```
+
+## FAQ
+
+### Won't this be slower?
+
+**No.** Distrobox has negligible overhead. Your projects are on the same filesystem, not copied.
+
+### What about `$GOPATH` and cached dependencies?
+
+They're stored in the toolbox's home directory. Each toolbox has its own cache.
+
+To share the cache:
+```bash
+# Create toolbox with shared GOPATH
+distrobox create -n go-dev \
+    --volume $HOME/go:/home/$USER/go \
+    -i registry.fedoraproject.org/fedora-toolbox:42
+```
+
+### Can I use multiple toolboxes at once?
+
+**Yes!** You can have multiple terminal windows, each in different toolboxes.
+
+### What if I need Go on the host?
+
+Ask yourself: *why?*
+
+For development: Use distrobox
+For scripting: Use distrobox or Bash
+For system utilities: Consider if Go is the right choice
+
+If you really need it, you can install via Homebrew:
+```bash
+brew install go
+```
+
+But the recommended approach is distrobox.
+
+### How do I update Go?
+
+```bash
+# Enter the toolbox
+distrobox enter go-dev
+
+# Update Go
+sudo dnf upgrade golang
+
+# Or recreate the toolbox with latest Fedora
+distrobox rm go-dev
+ujust create-go-toolbox
+```
+
+## Recommended Setup
+
+```bash
+# 1. Deploy Hublue (Go removed from system)
+# 2. Create Go toolbox
+ujust create-go-toolbox
+
+# 3. Add convenience alias
+echo 'alias go-dev="distrobox enter go-dev"' >> ~/.zshrc
+
+# 4. Develop!
+go-dev
+cd ~/Projects/myproject
+go build
+```
+
+## Resources
+
+- [Distrobox Documentation](https://distrobox.it/)
+- [Universal Blue Guide](https://universal-blue.org/guide/toolbox/)
+- [Go Installation Guide](https://go.dev/doc/install)
+- [Fedora Toolbox](https://docs.fedoraproject.org/en-US/fedora-silverblue/toolbox/)
+
+## Summary
+
+**Remove Go from system level. Use distrobox instead.**
+
+**Benefits:**
+- ✅ Smaller base image (-280MB)
+- ✅ Multiple Go versions
+- ✅ Easy updates
+- ✅ Project isolation
+- ✅ Best practice for immutable OS
+- ✅ More flexible
+
+**One command to set up:**
+```bash
+ujust create-go-toolbox
+```
+
+**Enter and develop:**
+```bash
+distrobox enter go-dev
+```
+
+Done! 🎉

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -1,0 +1,487 @@
+# Hublue Installation Guide
+
+## Quick Reference
+
+**Current laptop (already running Hublue):**
+```bash
+git add . && git commit -m "Update" && git push
+# Wait for GitHub Actions build to complete
+ujust update && systemctl reboot
+```
+
+**New laptop from Bluefin/Bazzite:**
+```bash
+rpm-ostree rebase ostree-unverified-registry:ghcr.io/hubeadmin/hublue:latest
+systemctl reboot
+```
+
+---
+
+## Installation Methods
+
+### Method 1: Update Existing Hublue System (This Laptop)
+
+You're already running Hublue! Just update to get the latest changes.
+
+#### Step 1: Commit and Push Your Changes
+
+```bash
+cd ~/Projects/github.com/hubeadmin/hublue
+
+# Add all your new files
+git add .
+
+# Commit your changes
+git commit -m "Add ujust-picker, improved user-space management, Go in distrobox"
+
+# Push to GitHub (triggers automatic build)
+git push origin main
+```
+
+#### Step 2: Monitor the Build
+
+1. Go to https://github.com/hubeadmin/hublue/actions
+2. Click on the latest "Build Custom Image" workflow
+3. Wait for it to complete (usually 5-10 minutes)
+4. You'll see: ✅ Build and push image
+
+#### Step 3: Update Your System
+
+```bash
+# Update to the latest image
+ujust update
+
+# Or manually
+rpm-ostree update
+
+# Check what will change
+rpm-ostree status
+
+# Reboot to apply
+systemctl reboot
+```
+
+#### Step 4: First Time Setup (After Reboot)
+
+```bash
+# Try the new interactive picker!
+ujust-picker
+
+# Run complete user setup
+ujust setup-user
+
+# Create Go development environment
+ujust create-go-toolbox
+```
+
+---
+
+### Method 2: Rebase from Bluefin/Bazzite/Aurora (Existing Install)
+
+If you have another laptop running Bluefin, Bazzite, or Aurora, you can switch to Hublue without reinstalling.
+
+#### Prerequisites
+- Laptop running Bluefin, Bazzite, Aurora, or any Universal Blue image
+- Internet connection
+
+#### Steps
+
+1. **Rebase to Hublue:**
+   ```bash
+   rpm-ostree rebase ostree-unverified-registry:ghcr.io/hubeadmin/hublue:latest
+   ```
+
+2. **Wait for download** (this will download the entire image, ~3-5GB)
+
+3. **Reboot:**
+   ```bash
+   systemctl reboot
+   ```
+
+4. **After reboot, verify:**
+   ```bash
+   rpm-ostree status
+   # Should show: ghcr.io/hubeadmin/hublue:latest
+   ```
+
+5. **Run user setup:**
+   ```bash
+   ujust-picker    # Interactive TUI
+   ujust setup-user # Complete setup
+   ```
+
+#### Reverting Back
+
+If you want to go back to Bluefin:
+```bash
+rpm-ostree rebase ostree-image-signed:docker://ghcr.io/ublue-os/bluefin-nvidia:stable
+systemctl reboot
+```
+
+---
+
+### Method 3: Fresh Install via ISO (New Machine or Clean Install)
+
+Build a bootable ISO for a fresh installation.
+
+#### Step 1: Update iso.toml
+
+Already done! The file is configured with `ghcr.io/hubeadmin/hublue:latest`
+
+#### Step 2: Trigger ISO Build
+
+**Option A: Via GitHub Web UI**
+1. Go to https://github.com/hubeadmin/hublue/actions
+2. Click "Build ISOs" workflow
+3. Click "Run workflow"
+4. Select platform: `amd64`
+5. Click "Run workflow"
+
+**Option B: Via GitHub CLI**
+```bash
+gh workflow run build-iso.yml -f platform=amd64
+```
+
+#### Step 3: Download the ISO
+
+After the workflow completes (~15-20 minutes):
+
+1. Go to the workflow run
+2. Scroll to "Artifacts" section
+3. Download the ISO (or it will be in your S3 bucket if configured)
+
+#### Step 4: Create Bootable USB
+
+**On Linux:**
+```bash
+# Find your USB device
+lsblk
+
+# Write ISO to USB (replace /dev/sdX with your USB device)
+sudo dd if=hublue.iso of=/dev/sdX bs=4M status=progress && sync
+```
+
+**On Windows:**
+- Use [Rufus](https://rufus.ie/) or [Ventoy](https://www.ventoy.net/)
+
+**On macOS:**
+```bash
+# Find your USB device
+diskutil list
+
+# Unmount the USB
+diskutil unmountDisk /dev/diskX
+
+# Write ISO
+sudo dd if=hublue.iso of=/dev/rdiskX bs=1m
+```
+
+#### Step 5: Boot and Install
+
+1. Insert USB into target laptop
+2. Boot from USB (usually F12, F2, or Del during startup)
+3. Follow the installation wizard
+4. Reboot after installation
+
+#### Step 6: First Boot Setup
+
+```bash
+# Launch interactive picker
+ujust-picker
+
+# Complete user setup
+ujust setup-user
+
+# Optional: Create Go development environment
+ujust create-go-toolbox
+```
+
+---
+
+### Method 4: Local Build and Deploy (Testing)
+
+For testing changes locally before pushing to GitHub.
+
+#### Build Locally
+
+```bash
+cd ~/Projects/github.com/hubeadmin/hublue
+
+# Build with podman
+podman build -t localhost/hublue:testing -f Containerfile .
+
+# Or use the build script
+./build-and-push.sh
+```
+
+#### Rebase to Local Image
+
+```bash
+# Rebase to your local build
+rpm-ostree rebase ostree-unverified-registry:localhost/hublue:testing
+
+# Reboot
+systemctl reboot
+```
+
+#### Switch Back to Remote
+
+```bash
+# Switch back to the GitHub-built image
+rpm-ostree rebase ostree-unverified-registry:ghcr.io/hubeadmin/hublue:latest
+systemctl reboot
+```
+
+---
+
+## Post-Installation Setup
+
+After installing Hublue via any method, run these commands:
+
+### Essential Setup
+
+```bash
+# 1. Interactive command picker (explore what's available)
+ujust-picker
+
+# 2. Complete user setup (Homebrew, tools, shell config)
+ujust setup-user
+
+# 3. Set zsh as default shell (optional)
+ujust set-zsh-default
+```
+
+### Development Setup
+
+```bash
+# Create Go development environment
+ujust create-go-toolbox
+
+# Enter and test
+distrobox enter go-dev
+go version
+exit
+```
+
+### Verify Installation
+
+```bash
+# Check system status
+rpm-ostree status
+
+# Check installed tools
+which ujust-picker eza bat starship atuin
+
+# List all available commands
+ujust --list
+
+# Check distrobox
+distrobox list
+```
+
+---
+
+## Automatic Updates
+
+Hublue is configured to check for updates daily.
+
+### Check for Updates Manually
+
+```bash
+# Update system image
+ujust update
+
+# Update user packages
+ujust update-user
+
+# Update all distroboxes
+distrobox upgrade --all
+```
+
+### Disable Automatic Updates
+
+```bash
+# Disable automatic updates
+sudo systemctl disable rpm-ostreed-automatic.timer
+
+# Re-enable
+sudo systemctl enable rpm-ostreed-automatic.timer
+```
+
+---
+
+## Multiple Machines
+
+### Scenario 1: Same Setup on All Machines
+
+Use the same image on all machines:
+
+```bash
+# On each machine
+rpm-ostree rebase ostree-unverified-registry:ghcr.io/hubeadmin/hublue:latest
+systemctl reboot
+ujust setup-user
+```
+
+### Scenario 2: Machine-Specific Customizations
+
+Use image tags for different configs:
+
+```bash
+# Build different tags in GitHub Actions
+# Then on work laptop:
+rpm-ostree rebase ostree-unverified-registry:ghcr.io/hubeadmin/hublue:work
+
+# On personal laptop:
+rpm-ostree rebase ostree-unverified-registry:ghcr.io/hubeadmin/hublue:personal
+```
+
+### Scenario 3: Sync Dotfiles Across Machines
+
+Use chezmoi (already installed via Homebrew):
+
+```bash
+# On first machine
+chezmoi init
+chezmoi add ~/.zshrc ~/.bashrc
+cd ~/.local/share/chezmoi
+git init && git add . && git commit -m "Initial dotfiles"
+git remote add origin git@github.com:yourusername/dotfiles.git
+git push
+
+# On other machines (after ujust setup-user)
+chezmoi init --apply git@github.com:yourusername/dotfiles.git
+```
+
+---
+
+## Verification
+
+After installation, verify everything is working:
+
+```bash
+# Check system
+rpm-ostree status | grep hublue
+
+# Check ujust commands
+ujust --list
+
+# Check interactive picker
+ujust-picker
+
+# Check Homebrew (after setup-user)
+brew --version
+
+# Check shell enhancements
+starship --version
+atuin --version
+eza --version
+
+# Check distrobox
+distrobox list
+```
+
+---
+
+## Troubleshooting
+
+### Build Failed on GitHub Actions
+
+1. Check the workflow logs at https://github.com/hubeadmin/hublue/actions
+2. Common issues:
+   - Network timeout downloading packages
+   - COPR repository temporarily unavailable
+   - Syntax error in build.sh
+
+**Solution:** Re-run the workflow or fix the error and push again
+
+### Rebase Failed
+
+```bash
+# Check current status
+rpm-ostree status
+
+# Cancel any pending deployment
+rpm-ostree cancel
+
+# Try again
+rpm-ostree rebase ostree-unverified-registry:ghcr.io/hubeadmin/hublue:latest
+```
+
+### Stuck on Old Image
+
+```bash
+# Force check for updates
+rpm-ostree update --check
+
+# Force download
+rpm-ostree update --preview
+
+# Apply update
+rpm-ostree update
+systemctl reboot
+```
+
+### ujust-picker Not Found
+
+The tool is only available after you've built and deployed the updated image with the changes we just made.
+
+**Current system:**
+```bash
+rpm-ostree status
+# Check the timestamp - if it's older than your latest build, update
+```
+
+**Update to latest:**
+```bash
+rpm-ostree update
+systemctl reboot
+```
+
+### Homebrew Installation Failed
+
+```bash
+# Run setup again (it's idempotent)
+ujust setup-user
+
+# Or install Homebrew manually
+ujust install-brew
+```
+
+---
+
+## Next Steps
+
+After successful installation:
+
+1. **Read the documentation:**
+   - [USER-SETUP.md](USER-SETUP.md) - Complete setup guide
+   - [CHEATSHEET.md](CHEATSHEET.md) - Quick command reference
+   - [GO-DEVELOPMENT.md](GO-DEVELOPMENT.md) - Go development workflow
+
+2. **Customize your setup:**
+   - Edit Brewfile: `cp /usr/share/hublue/Brewfile ~/Brewfile`
+   - Add custom ujust commands: Edit `/usr/share/ublue-os/just/60-hublue.just`
+   - Configure shell: Edit `~/.zshrc` or `~/.bashrc`
+
+3. **Create development environments:**
+   ```bash
+   ujust create-go-toolbox
+   ujust create-dev-toolbox myproject
+   ```
+
+4. **Keep your system updated:**
+   ```bash
+   ujust update        # System
+   ujust update-user   # User packages
+   ```
+
+---
+
+## Support
+
+- **GitHub Issues:** https://github.com/hubeadmin/hublue/issues
+- **Universal Blue Docs:** https://universal-blue.org/
+- **Bluefin Docs:** https://projectbluefin.io/
+
+Enjoy your Hublue system! 🎉

--- a/README.md
+++ b/README.md
@@ -1,6 +1,64 @@
-# image-template
+# Hublue
 
-# Purpose
+**Custom Bluefin-NVIDIA image with developer tools and modern CLI utilities.**
+
+## Quick Start
+
+After deploying Hublue to your system:
+
+```bash
+# Interactive TUI to browse and run commands (easiest!)
+ujust-picker
+# or: ujust picker
+
+# One-command setup for user-space tools
+ujust setup-user
+
+# Create Go development environment
+ujust create-go-toolbox
+```
+
+### What's Included
+
+**System-level (in the image):**
+- Neovim, zsh, ghostty, zellij
+- Podman, buildah, libvirt/KVM
+- Terraform, AWS CLI, Google Cloud CLI
+- Development tools (clang, cmake, ninja, etc.)
+- **ujust-picker** - Interactive TUI for command discovery
+
+**User-level (via `ujust setup-user`):**
+- Homebrew + modern CLI tools (eza, bat, fd, starship, atuin, zoxide, etc.)
+- oh-my-zsh with shell enhancements
+- kubectl, gh (GitHub CLI), kubecolor
+- Automatic shell configuration
+
+**Development (via distrobox):**
+- Go toolbox: `ujust create-go-toolbox`
+- Custom toolboxes for project isolation
+
+### Documentation
+
+- **[USER-SETUP.md](USER-SETUP.md)** - Complete user setup guide
+- **[GO-DEVELOPMENT.md](GO-DEVELOPMENT.md)** - Go development workflow
+- **[COMPARISON.md](COMPARISON.md)** - User-space management approaches
+- **[SECURE-BOOT.md](SECURE-BOOT.md)** - Secure Boot compatibility guide
+- **[build_files/README.md](build_files/README.md)** - Technical build documentation
+
+### Available Commands
+
+Run `ujust-picker` or `ujust --list` to see all commands, including:
+- `ujust setup-user` - Complete user setup
+- `ujust install-brew` - Install Homebrew
+- `ujust update-user` - Update all user packages
+- `ujust create-go-toolbox` - Create Go development environment
+- `ujust picker` - Launch interactive command picker
+
+---
+
+# Universal Blue Image Template
+
+## Purpose
 
 This repository is meant to be a template for building your own custom [bootc](https://github.com/bootc-dev/bootc) image. This template is the recommended way to make customizations to any image published by the Universal Blue Project:
 - Products: [Aurora](https://getaurora.dev/), [Bazzite](https://bazzite.gg/), [Bluefin](https://projectbluefin.io/), [uCore](https://projectucore.io/)

--- a/SECURE-BOOT.md
+++ b/SECURE-BOOT.md
@@ -1,0 +1,138 @@
+# Secure Boot Guide for Hublue
+
+## Current Status
+Your image is **fully compatible** with Secure Boot because:
+- Base image (bluefin-nvidia) is signed and Secure Boot ready
+- NVIDIA drivers are signed with Microsoft UEFI keys
+- Build script only installs userspace packages
+- Images are signed with cosign
+
+## Enabling Secure Boot
+
+### 1. Enter UEFI/BIOS Settings
+- Reboot your computer
+- Press the appropriate key during boot (usually F2, F10, F12, Del, or Esc)
+- Look for "UEFI Firmware Settings" or similar
+
+### 2. Enable Secure Boot
+Navigate to:
+- **Security** → **Secure Boot** → **Enabled**
+- Or: **Boot** → **Secure Boot** → **Enabled**
+
+### 3. Set Secure Boot Mode
+- Choose **Microsoft UEFI CA** or **Standard** mode (NOT "Custom")
+- This ensures the NVIDIA drivers will be recognized
+
+### 4. Clear/Reset Keys (if needed)
+- If you had custom keys, reset to factory defaults
+- Option usually called "Restore Factory Keys" or "Clear Secure Boot Keys"
+
+### 5. Save and Reboot
+- Save settings (usually F10)
+- System will reboot
+
+### 6. Verify Secure Boot is Active
+After boot, run:
+```bash
+mokutil --sb-state
+# Should show: SecureBoot enabled
+```
+
+Or:
+```bash
+bootctl status | grep "Secure Boot"
+# Should show: Secure Boot: enabled (user)
+```
+
+## Maintaining Secure Boot Compatibility
+
+### ✅ Safe to Do (Won't Break Secure Boot)
+- Install packages via DNF/Homebrew
+- Install flatpaks
+- Run containers (Podman/Docker)
+- Update the base image
+- Add configuration files
+- Install Go, Rust, Node.js, etc.
+
+### ❌ Will Break Secure Boot
+- Installing unsigned kernel modules
+- Building custom kernel drivers
+- Using third-party kernel modules not signed by Microsoft
+- Installing VirtualBox (use libvirt/KVM instead - already in your build!)
+
+## Verifying Your Image Works with Secure Boot
+
+### Check Image Signature
+```bash
+# Verify the cosign signature
+cosign verify \
+  --key cosign.pub \
+  ghcr.io/hubeadmin/hublue:latest
+```
+
+### Check Base Image
+```bash
+# Verify the base image is signed
+rpm-ostree status
+```
+
+## If Secure Boot Fails to Enable
+
+### Common Issues:
+
+1. **"Validation Failed" on Boot**
+   - Reset Secure Boot keys to factory defaults
+   - Make sure you're using "Microsoft UEFI CA" mode
+
+2. **NVIDIA Driver Issues**
+   - The bluefin-nvidia base already has signed NVIDIA drivers
+   - Don't manually install NVIDIA drivers
+
+3. **Can't Find Secure Boot in BIOS**
+   - Some systems require setting a BIOS/supervisor password first
+   - Disable Legacy/CSM mode - use UEFI only
+
+4. **Custom Hardware**
+   - Some motherboards have Secure Boot hidden/disabled in consumer mode
+   - Check if there's a "Windows Mode" or "Other OS" setting
+
+## Testing After Enabling Secure Boot
+
+1. Enable Secure Boot in BIOS
+2. Reboot to your hublue image
+3. Run verification:
+```bash
+# Check Secure Boot status
+mokutil --sb-state
+
+# Check kernel is signed
+dmesg | grep -i "secure boot"
+
+# Check NVIDIA drivers loaded
+nvidia-smi
+
+# Verify ostree status
+rpm-ostree status
+```
+
+## Additional Security
+
+Your image is already signed with cosign. To verify future updates:
+
+```bash
+# Add your public key to the system
+sudo cp cosign.pub /etc/pki/containers/
+
+# Configure podman to verify signatures
+sudo mkdir -p /etc/containers/registries.d/
+sudo tee /etc/containers/registries.d/ghcr.io-hubeadmin.yaml <<EOF
+docker:
+  ghcr.io/hubeadmin:
+    use-sigstore-attachments: true
+EOF
+```
+
+## Resources
+- [Universal Blue Secure Boot Guide](https://universal-blue.org/guide/secure-boot/)
+- [Fedora Secure Boot Documentation](https://docs.fedoraproject.org/en-US/fedora-silverblue/troubleshooting/#_secure_boot)
+- [NVIDIA Driver Signing](https://github.com/ublue-os/nvidia)

--- a/USER-SETUP.md
+++ b/USER-SETUP.md
@@ -1,0 +1,301 @@
+# Hublue User Setup Guide
+
+This guide shows you multiple resilient ways to set up your user environment on Hublue.
+
+## 🌟 Recommended: ujust Commands (Universal Blue Standard)
+
+The **best and most resilient** way to manage user-space on Hublue is using `ujust` commands.
+
+### Quick Start
+
+After deploying Hublue, run:
+
+```bash
+# Complete setup in one command
+ujust setup-user
+```
+
+That's it! This will:
+- ✅ Install Homebrew
+- ✅ Install oh-my-zsh
+- ✅ Install all Homebrew packages from Brewfile
+- ✅ Install kubecolor
+- ✅ Configure your shell (bash and zsh)
+
+### Individual Commands
+
+You can also run setup steps individually:
+
+```bash
+# Interactive picker (TUI) - easiest way!
+ujust picker
+# Or directly: ujust-picker
+
+# List all commands with descriptions
+ujust --choose
+
+# List all hublue commands
+ujust --list
+
+# Install just Homebrew
+ujust install-brew
+
+# Install just oh-my-zsh
+ujust install-omz
+
+# Install Homebrew packages from Brewfile
+ujust install-brew-packages
+
+# Configure shell environment
+ujust configure-shell
+
+# Install kubecolor
+ujust install-kubecolor
+
+# Set zsh as default shell
+ujust set-zsh-default
+
+# Update all Homebrew packages
+ujust update-user
+```
+
+### Why ujust is Better
+
+**Resilient:**
+- ✅ Built into the system image
+- ✅ Idempotent (safe to run multiple times)
+- ✅ Survives system updates
+- ✅ Self-documenting (`ujust --list`)
+
+**Universal Blue Standard:**
+- ✅ Same pattern as system updates (`ujust update`)
+- ✅ Discoverable with tab-completion and interactive picker (`ujust picker`)
+- ✅ Integrated with the ecosystem
+
+**Flexible:**
+- ✅ Run all at once or step-by-step
+- ✅ Beautiful TUI with `ujust-picker` for easy browsing
+- ✅ Easy to customize by editing `/usr/share/ublue-os/just/60-hublue.just`
+- ✅ Can be called from scripts or automation
+
+## 📦 Declarative Package Management with Brewfile
+
+Your Homebrew packages are defined in `/usr/share/hublue/Brewfile`:
+
+```ruby
+# View the Brewfile
+cat /usr/share/hublue/Brewfile
+
+# Install all packages
+brew bundle --file=/usr/share/hublue/Brewfile
+
+# Or use ujust
+ujust install-brew-packages
+
+# Update packages
+ujust update-user
+```
+
+**Benefits:**
+- ✅ Declarative (version-controlled list of packages)
+- ✅ Reproducible across machines
+- ✅ Easy to add/remove packages
+
+**To customize:**
+1. Copy Brewfile to your home: `cp /usr/share/hublue/Brewfile ~/Brewfile`
+2. Edit it: `nano ~/Brewfile`
+3. Apply changes: `brew bundle --file=~/Brewfile`
+
+## 🔧 Alternative Approaches
+
+### 1. Distrobox/Toolbox (Recommended for Development)
+
+Instead of installing development tools on the host, use containers:
+
+```bash
+# Create a development toolbox
+ujust create-dev-toolbox mydev
+
+# Enter it
+distrobox enter mydev
+
+# Install anything you want inside
+sudo dnf install python3 nodejs rust golang
+
+# Use it like your normal shell
+# Exit with: exit
+```
+
+**Benefits:**
+- ✅ Isolated from host system
+- ✅ Can install any packages without affecting the host
+- ✅ Multiple environments for different projects
+- ✅ Easy to delete and recreate
+
+**When to use:**
+- Project-specific dependencies (Python, Node.js, etc.)
+- Experimental tools
+- Different language versions
+
+### 2. Fleek (Nix-based User Environment)
+
+For maximum reproducibility, consider [Fleek](https://getfleek.dev/):
+
+```bash
+# Install Fleek
+curl -fsSL https://getfleek.dev/installer | bash
+
+# Define your environment
+fleek init
+
+# Install packages
+fleek add eza starship atuin
+```
+
+**Benefits:**
+- ✅ Declarative (YAML config)
+- ✅ Nix package manager (huge package selection)
+- ✅ Per-user, doesn't require root
+- ✅ Reproducible across any Linux system
+
+### 3. Chezmoi (Dotfile Management)
+
+Already installed via Homebrew! Manage your dotfiles:
+
+```bash
+# Initialize chezmoi
+chezmoi init
+
+# Add your dotfiles
+chezmoi add ~/.zshrc ~/.bashrc
+
+# Apply on another machine
+chezmoi init --apply https://github.com/yourusername/dotfiles.git
+```
+
+
+### 4. Automatic Setup (Optional)
+
+Want setup to run automatically on first login?
+
+Edit `/var/home/hubeadmin/Projects/github.com/hubeadmin/hublue/build_files/build.sh` and uncomment these lines:
+
+```bash
+# Optional: Install systemd user unit for auto-setup (commented out by default)
+# mkdir -p /etc/skel/.config/systemd/user/default.target.wants
+# cp /ctx/hublue-setup.service /etc/skel/.config/systemd/user/hublue-setup.service
+# ln -sf ../hublue-setup.service /etc/skel/.config/systemd/user/default.target.wants/hublue-setup.service
+```
+
+This will run `ujust setup-user` automatically on first login.
+
+## 📋 What Gets Installed Where
+
+### System (via build.sh - immutable)
+```
+/usr/bin/                          # DNF packages
+/usr/local/bin/go/                 # Go language
+/usr/share/hublue/                 # Config files
+/usr/share/ublue-os/just/          # ujust commands
+```
+
+### User (via ujust setup-user - mutable)
+```
+/home/linuxbrew/.linuxbrew/        # Homebrew + packages
+~/.oh-my-zsh/                      # Oh-my-zsh
+~/.local/bin/                      # User binaries
+~/.bashrc, ~/.zshrc                # Shell configs
+```
+
+### Distrobox (via ujust create-dev-toolbox)
+```
+~/.local/share/containers/storage/  # Container images
+```
+
+## 🔄 Updates and Maintenance
+
+```bash
+# Update system image
+ujust update
+
+# Update user packages
+ujust update-user
+
+# Update distrobox images
+distrobox upgrade --all
+```
+
+## 🎯 Best Practices
+
+### For Most Users
+1. **Use ujust** for user setup: `ujust setup-user`
+2. **Use Brewfile** to manage packages declaratively
+3. **Use distrobox** for project-specific dev environments
+
+### For Power Users
+1. **Use ujust** for quick setup
+2. **Use Fleek** for fully declarative user environment
+3. **Use chezmoi** to sync dotfiles across machines
+4. **Use distrobox** extensively for isolated environments
+
+### For Teams
+1. **Fork this repo** and customize Brewfile/ujust commands
+2. **Document** team-specific tools in the Brewfile
+3. **Share** the custom image with the team
+4. Everyone runs: `ujust setup-user` on first boot
+
+## 🐛 Troubleshooting
+
+### ujust command not found
+```bash
+# Check if ujust is installed
+which ujust
+
+# If not, it's included in Universal Blue images by default
+# You might be on a different base image
+```
+
+### Homebrew installation fails
+```bash
+# Check internet connectivity
+ping -c 3 github.com
+
+# Check disk space
+df -h /home
+
+# Manually install
+NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+### Commands not in PATH after setup
+```bash
+# Restart terminal or source config
+source ~/.bashrc  # or ~/.zshrc
+
+# Or logout and login again
+```
+
+### Want to start fresh
+```bash
+# Remove Homebrew
+rm -rf /home/linuxbrew/.linuxbrew
+
+# Remove oh-my-zsh
+rm -rf ~/.oh-my-zsh
+
+# Reset shell configs (careful!)
+cp ~/.bashrc.backup.YYYYMMDD_HHMMSS ~/.bashrc
+cp ~/.zshrc.backup.YYYYMMDD_HHMMSS ~/.zshrc
+
+# Run setup again
+ujust setup-user
+```
+
+## 📚 Further Reading
+
+- [Universal Blue Docs](https://universal-blue.org/)
+- [Just Command Runner](https://github.com/casey/just)
+- [Homebrew Documentation](https://docs.brew.sh/)
+- [Distrobox Documentation](https://distrobox.it/)
+- [Fleek Documentation](https://getfleek.dev/docs)
+- [Chezmoi Documentation](https://www.chezmoi.io/)

--- a/build_files/Brewfile
+++ b/build_files/Brewfile
@@ -1,0 +1,25 @@
+# Hublue Homebrew Bundle
+# Install with: brew bundle --file=/usr/share/hublue/Brewfile
+# Or: ujust install-brew-packages
+
+# Modern CLI replacements
+brew "eza"          # Modern ls
+brew "bat"          # Modern cat with syntax highlighting
+brew "fd"           # Modern find
+brew "ugrep"        # Modern grep
+
+# Shell enhancements
+brew "starship"     # Modern shell prompt
+brew "atuin"        # Shell history in SQLite
+brew "zoxide"       # Smart cd
+brew "direnv"       # Directory-based environment variables
+
+# Development tools
+brew "gh"           # GitHub CLI
+brew "kubectl"      # Kubernetes CLI
+brew "yq"           # YAML processor
+brew "chezmoi"      # Dotfile manager
+
+# Optional: Add more tools as needed
+# brew "terraform"  # Already installed via DNF
+# brew "go"         # Already installed in /usr/local/bin

--- a/build_files/README.md
+++ b/build_files/README.md
@@ -1,0 +1,132 @@
+# Hublue Build Files
+
+This directory contains scripts for building and configuring the Hublue custom image.
+
+## Files
+
+### build.sh
+**Runs during container build** (image creation time)
+
+Installs system-level packages and tools:
+- DNF packages (neovim, nodejs, cargo, etc.)
+- Go programming language
+- Zellij (terminal multiplexer)
+- Ghostty (terminal emulator)
+- Virtualization tools (libvirt, podman, buildah)
+- Development tools (clang, cmake, ninja, etc.)
+
+This script runs in the containerized build environment, so it cannot install user-level tools like Homebrew.
+
+### hublue.just
+**ujust commands** for user setup
+
+Provides resilient, idempotent commands for user-space setup:
+- `ujust setup-user` - Complete setup in one command
+- `ujust install-brew` - Install Homebrew
+- `ujust install-omz` - Install oh-my-zsh
+- `ujust install-brew-packages` - Install packages from Brewfile
+- `ujust configure-shell` - Configure shell environment
+- `ujust update-user` - Update all user packages
+
+### Brewfile
+**Declarative package management**
+
+Defines all Homebrew packages to install:
+- eza, bat, fd, ugrep (modern CLI tools)
+- starship, atuin, zoxide, direnv (shell enhancements)
+- kubectl, gh, yq, chezmoi (development tools)
+
+### hublue-setup.service
+**Optional systemd user unit**
+
+Can be enabled for automatic setup on first login (commented out by default).
+
+## Usage
+
+### Building the Image
+
+The image is automatically built by GitHub Actions when you push to main.
+
+To build locally:
+```bash
+# Using the build script
+./build-and-push.sh
+
+# Or manually with podman
+podman build -t hublue:latest -f Containerfile .
+```
+
+### After First Boot (Recommended)
+
+**Use ujust** - the Universal Blue standard way:
+
+```bash
+# Interactive TUI picker (easiest!)
+ujust picker
+# or: ujust-picker
+
+# Complete setup in one command
+ujust setup-user
+
+# Or step-by-step
+ujust install-brew
+ujust install-omz
+ujust install-brew-packages
+ujust configure-shell
+```
+
+**Benefits:**
+- ✅ Idempotent (safe to run multiple times)
+- ✅ Self-documenting (`ujust --list`)
+- ✅ Beautiful interactive TUI with `ujust-picker`
+- ✅ Integrated with Universal Blue ecosystem
+- ✅ Survives system updates
+
+See [USER-SETUP.md](../USER-SETUP.md) for detailed guide.
+
+### What Gets Installed Where
+
+**System-level (via build.sh)**
+- `/usr/bin/` - DNF packages
+- `/usr/local/bin/go/` - Go language
+- `/usr/share/hublue/` - Brewfile and config files
+- `/usr/share/ublue-os/just/` - ujust commands
+
+**User-level (via ujust setup-user)**
+- `/home/linuxbrew/.linuxbrew/` - Homebrew and its packages
+- `~/.oh-my-zsh/` - Oh-my-zsh
+- `~/.local/bin/` - User binaries (kubecolor)
+- `~/.bashrc` and `~/.zshrc` - Shell configurations
+
+## Troubleshooting
+
+### "File exists" error during build
+This happens if you try to install Homebrew during container build. Homebrew must be installed after boot via `ujust setup-user`.
+
+### Permission denied
+Make sure you're NOT running ujust commands with sudo. Run them as your regular user.
+
+### Homebrew installation fails
+Make sure you have internet connectivity and sufficient disk space. Homebrew needs about 1GB.
+
+### Tools not in PATH
+After running `ujust setup-user`, restart your terminal or run:
+```bash
+source ~/.bashrc  # or ~/.zshrc if using zsh
+```
+
+### ujust command not found
+ujust is included in all Universal Blue images. If it's missing:
+```bash
+rpm-ostree install just
+systemctl reboot
+```
+
+## Secure Boot
+
+This image is fully compatible with Secure Boot because:
+- Base image (bluefin-nvidia) is signed
+- No kernel modules are installed
+- All packages are from official repos or built from source
+
+See [SECURE-BOOT.md](../SECURE-BOOT.md) for more details.

--- a/build_files/build.sh
+++ b/build_files/build.sh
@@ -18,44 +18,7 @@ dnf5 -y copr enable scottames/ghostty || {
   exit 1
 }
 
-echo "📦 Enabling COPR for arm cross podman-compose"
-dnf5 -y copr enable lantw44/aarch64-linux-gnu-toolchain || {
-  echo "❌ Failed to enable COPR lantw44/aarch64-linux-gnu-toolchain "
-  exit 1
-}
-
-sudo dnf config-manager --add-repo https://rpm.releases.hashicorp.com/fedora/hashicorp.repo
-
-echo "📦 Adding Google Cloud CLI repository..."
-# Detect RHEL/Fedora version to use appropriate repository
-if grep -q "release 10" /etc/redhat-release 2>/dev/null; then
-  # RHEL 10-compatible systems
-  sudo tee -a /etc/yum.repos.d/google-cloud-sdk.repo << EOM
-[google-cloud-cli]
-name=Google Cloud CLI
-baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el10-x86_64
-enabled=1
-gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/rpm-package-key-v10.gpg
-EOM
-else
-  # RHEL 7, 8, 9 and Fedora systems
-  sudo tee -a /etc/yum.repos.d/google-cloud-sdk.repo << EOM
-[google-cloud-cli]
-name=Google Cloud CLI
-baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el9-x86_64
-enabled=1
-gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
-EOM
-fi
-
-echo "📦 Installing libxcrypt-compat for Google Cloud CLI compatibility..."
-dnf5 install -y libxcrypt-compat.x86_64 || {
-  echo "⚠️  Failed to install libxcrypt-compat (may not be critical)"
-}
+dnf config-manager --add-repo https://rpm.releases.hashicorp.com/fedora/hashicorp.repo
 
 echo "📦 Installing DNF packages..."
 dnf5 install -y \
@@ -68,8 +31,6 @@ dnf5 install -y \
   xclip \
   awscli2 \
   zellij \
-  krb5-workstation \
-  krb5-devel \
   libvirt \
   clang \
   ninja-build \
@@ -80,6 +41,7 @@ dnf5 install -y \
   luarocks \
   zlib-devel \
   podman-compose \
+  buildah \
   cmake \
   texinfo \
   ninja-build \
@@ -87,20 +49,52 @@ dnf5 install -y \
   libtool \
   automake \
   pkg-config \
-  ImageMagick \
   patch \
   gtk3 \
   webkit2gtk4.1 \
   libusb \
   ghostty \
-  google-cloud-cli \
   @virtualization || {
   echo "❌ Failed to install DNF packages"
   exit 1
 }
 
-echo "⬇️Installing Oh-my-ZSH"
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+echo "📦 Installing zsh..."
+dnf5 install -y zsh || {
+  echo "❌ Failed to install zsh"
+  exit 1
+}
+
+echo "📦 Installing ujust-picker (TUI for ujust commands)..."
+UJUST_PICKER_VERSION=$(curl -s https://api.github.com/repos/ublue-os/bazzite-ujust-picker/releases/latest | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
+curl -L "https://github.com/ublue-os/bazzite-ujust-picker/releases/download/${UJUST_PICKER_VERSION}/bazzite-ujust-picker_Linux_x86_64" -o /usr/local/bin/ujust-picker
+chmod +x /usr/local/bin/ujust-picker
+echo "✅ ujust-picker installed"
+
+echo "📝 Installing user setup files..."
+mkdir -p /usr/share/hublue
+mkdir -p /usr/share/ublue-os/just
+mkdir -p /usr/share/hublue/distrobox-configs
+
+# Install just recipes for ujust
+cp /ctx/hublue.just /usr/share/ublue-os/just/60-hublue.just
+chmod +x /usr/share/ublue-os/just/60-hublue.just
+
+# Install Brewfile
+cp /ctx/Brewfile /usr/share/hublue/Brewfile
+
+# Install distrobox configs
+cp -r /ctx/distrobox-configs/* /usr/share/hublue/distrobox-configs/ 2>/dev/null || true
+
+# Optional: Install systemd user unit for auto-setup (commented out by default)
+# mkdir -p /etc/skel/.config/systemd/user/default.target.wants
+# cp /ctx/hublue-setup.service /etc/skel/.config/systemd/user/hublue-setup.service
+# ln -sf ../hublue-setup.service /etc/skel/.config/systemd/user/default.target.wants/hublue-setup.service
+
+echo "✅ User setup files installed"
+echo "   - Run after first boot: ujust setup-user"
+echo "   - Individual commands: ujust --choose"
+echo "   - Brewfile: /usr/share/hublue/Brewfile"
 
 ### Enable a systemd socket
 echo "🔌 Enabling podman.socket"

--- a/build_files/distrobox-configs/go-dev.ini
+++ b/build_files/distrobox-configs/go-dev.ini
@@ -1,0 +1,15 @@
+# Distrobox config for Go development
+# Create with: distrobox assemble create --file go-dev.ini
+# Or: ujust create-go-toolbox
+
+[go-dev]
+image=registry.fedoraproject.org/fedora-toolbox:42
+additional_packages="golang git make gcc"
+init=false
+nvidia=false
+pull=true
+root=false
+replace=true
+
+# Optional: Add Go tools
+# additional_packages="golang git make gcc gopls delve staticcheck"

--- a/build_files/hublue-setup.service
+++ b/build_files/hublue-setup.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Hublue First-Time User Setup
+ConditionPathExists=!/var/home/%u/.config/hublue/setup-complete
+After=default.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/just --justfile /usr/share/ublue-os/just/60-hublue.just setup-user
+ExecStartPost=/usr/bin/mkdir -p /var/home/%u/.config/hublue
+ExecStartPost=/usr/bin/touch /var/home/%u/.config/hublue/setup-complete
+RemainAfterExit=yes
+
+[Install]
+WantedBy=default.target

--- a/build_files/hublue.just
+++ b/build_files/hublue.just
@@ -1,0 +1,172 @@
+#!/usr/bin/env -S just --justfile
+
+# Install Homebrew
+[group('setup')]
+install-brew:
+    #!/usr/bin/bash
+    set -euo pipefail
+    if ! command -v brew &> /dev/null; then
+        echo "Installing Homebrew..."
+        NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+        eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+        echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> ~/.bashrc
+        [ -f ~/.zshrc ] && echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> ~/.zshrc
+        echo "✅ Homebrew installed"
+    else
+        echo "✅ Homebrew already installed"
+    fi
+
+# Install Homebrew packages from Brewfile
+[group('setup')]
+install-brew-packages:
+    #!/usr/bin/bash
+    set -euo pipefail
+    if [ -f /usr/share/hublue/Brewfile ]; then
+        echo "Installing Homebrew packages from Brewfile..."
+        brew bundle --file=/usr/share/hublue/Brewfile
+        echo "✅ Homebrew packages installed"
+    else
+        echo "❌ Brewfile not found at /usr/share/hublue/Brewfile"
+        exit 1
+    fi
+
+# Install oh-my-zsh
+[group('setup')]
+install-omz:
+    #!/usr/bin/bash
+    set -euo pipefail
+    if [ ! -d "$HOME/.oh-my-zsh" ]; then
+        echo "Installing oh-my-zsh..."
+        sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
+        echo "✅ oh-my-zsh installed"
+    else
+        echo "✅ oh-my-zsh already installed"
+    fi
+
+# Configure shell (zsh and bash)
+[group('setup')]
+configure-shell:
+    #!/usr/bin/bash
+    set -euo pipefail
+
+    echo "Configuring shell environment..."
+
+    # Configure zsh
+    if [ -f ~/.zshrc ]; then
+        cp ~/.zshrc ~/.zshrc.backup.$(date +%Y%m%d_%H%M%S) 2>/dev/null || true
+
+        grep -q "atuin init zsh" ~/.zshrc || echo 'eval "$(atuin init zsh)"' >> ~/.zshrc
+        grep -q "starship init zsh" ~/.zshrc || echo 'eval "$(starship init zsh)"' >> ~/.zshrc
+        grep -q "zoxide init zsh" ~/.zshrc || echo 'eval "$(zoxide init zsh)"' >> ~/.zshrc
+        grep -q "direnv hook zsh" ~/.zshrc || echo 'eval "$(direnv hook zsh)"' >> ~/.zshrc
+        grep -q 'alias k=' ~/.zshrc || echo 'alias k="kubecolor"' >> ~/.zshrc
+        grep -q 'alias tx=' ~/.zshrc || echo 'alias tx="toolbox"' >> ~/.zshrc
+
+        echo "✅ zsh configured"
+    fi
+
+    # Configure bash
+    if [ -f ~/.bashrc ]; then
+        cp ~/.bashrc ~/.bashrc.backup.$(date +%Y%m%d_%H%M%S) 2>/dev/null || true
+
+        grep -q "atuin init bash" ~/.bashrc || echo 'eval "$(atuin init bash)"' >> ~/.bashrc
+        grep -q "starship init bash" ~/.bashrc || echo 'eval "$(starship init bash)"' >> ~/.bashrc
+        grep -q "zoxide init bash" ~/.bashrc || echo 'eval "$(zoxide init bash)"' >> ~/.bashrc
+        grep -q "direnv hook bash" ~/.bashrc || echo 'eval "$(direnv hook bash)"' >> ~/.bashrc
+        grep -q 'alias k=' ~/.bashrc || echo 'alias k="kubectl"' >> ~/.bashrc
+
+        echo "✅ bash configured"
+    fi
+
+# Install kubecolor
+[group('setup')]
+install-kubecolor:
+    #!/usr/bin/bash
+    set -euo pipefail
+    if [ ! -f ~/.local/bin/kubecolor ] && [ ! -f /usr/local/bin/kubecolor ]; then
+        echo "Installing kubecolor..."
+        mkdir -p ~/.local/bin
+        KUBECOLOR_VERSION=$(curl -s https://api.github.com/repos/hidetatz/kubecolor/releases/latest | grep '"tag_name"' | sed -E 's/.*"v([^"]+)".*/\1/')
+        curl -L "https://github.com/hidetatz/kubecolor/releases/latest/download/kubecolor_$(uname -s)_$(uname -m).tar.gz" -o /tmp/kubecolor.tar.gz
+        tar -C /tmp -xzf /tmp/kubecolor.tar.gz
+        mv /tmp/kubecolor ~/.local/bin/kubecolor
+        chmod +x ~/.local/bin/kubecolor
+        rm -f /tmp/kubecolor.tar.gz
+        echo "✅ kubecolor installed to ~/.local/bin"
+    else
+        echo "✅ kubecolor already installed"
+    fi
+
+# Set zsh as default shell
+[group('setup')]
+set-zsh-default:
+    #!/usr/bin/bash
+    if [ "$SHELL" != "$(which zsh)" ]; then
+        chsh -s $(which zsh)
+        echo "✅ Default shell changed to zsh (logout to apply)"
+    else
+        echo "✅ zsh is already your default shell"
+    fi
+
+# Complete first-time setup (all-in-one)
+[group('setup')]
+setup-user: install-brew install-omz install-brew-packages install-kubecolor configure-shell
+    #!/usr/bin/bash
+    echo ""
+    echo "🎉 Hublue user setup complete!"
+    echo ""
+    echo "Next steps:"
+    echo "  1. Restart your terminal or run: source ~/.bashrc (or ~/.zshrc)"
+    echo "  2. (Optional) Set zsh as default: ujust set-zsh-default"
+    echo ""
+
+# Update all user-space tools
+[group('maintenance')]
+update-user:
+    #!/usr/bin/bash
+    set -euo pipefail
+    echo "Updating Homebrew packages..."
+    brew update && brew upgrade
+    echo "✅ Homebrew packages updated"
+
+# Create a development toolbox
+[group('development')]
+create-dev-toolbox NAME="dev":
+    #!/usr/bin/bash
+    echo "Creating development toolbox: {{ NAME }}"
+    distrobox create -n {{ NAME }} -i registry.fedoraproject.org/fedora-toolbox:42
+    echo "✅ Toolbox created. Enter with: distrobox enter {{ NAME }}"
+
+# Create a Go development toolbox
+[group('development')]
+create-go-toolbox:
+    #!/usr/bin/bash
+    echo "Creating Go development toolbox..."
+    if [ -f /usr/share/hublue/distrobox-configs/go-dev.ini ]; then
+        distrobox assemble create --file /usr/share/hublue/distrobox-configs/go-dev.ini
+    else
+        distrobox create -n go-dev \
+            -i registry.fedoraproject.org/fedora-toolbox:42 \
+            --additional-packages "golang git make gcc"
+    fi
+    echo "✅ Go toolbox created!"
+    echo "   Enter with: distrobox enter go-dev"
+    echo "   Or: toolbox enter go-dev"
+
+# List all custom ujust commands
+[group('info')]
+list-hublue:
+    @echo "Hublue Custom Commands:"
+    @just --list --justfile /usr/share/hublue/hublue.just
+
+# Interactive picker for ujust commands (TUI)
+[group('info')]
+picker:
+    #!/usr/bin/bash
+    if command -v ujust-picker &> /dev/null; then
+        ujust-picker
+    else
+        echo "❌ ujust-picker not installed"
+        echo "Install with: sudo dnf install -y ujust-picker"
+        exit 1
+    fi

--- a/iso.toml
+++ b/iso.toml
@@ -1,7 +1,7 @@
 [customizations.installer.kickstart]
 contents = """
 %post
-bootc switch --mutate-in-place --transport registry ghcr.io/yourrepo/yourimage:latest
+bootc switch --mutate-in-place --transport registry ghcr.io/hubeadmin/hublue:latest
 %end
 """
 


### PR DESCRIPTION
  - Add ujust-picker TUI for interactive command discovery
  - Move Go to distrobox (saves 280MB from base image)
  - Add comprehensive ujust commands for user setup
  - Add Brewfile for declarative package management
  - Add extensive documentation (INSTALLATION, USER-SETUP, CHEATSHEET, etc.)
  - Remove legacy post-install.sh in favor of ujust
  - Add distrobox configs for Go development
  - Update README with quick start guide